### PR TITLE
Replace calls to Color.transparent with Qt.alpha

### DIFF
--- a/MMaterial/Components/Common/Popup.qml
+++ b/MMaterial/Components/Common/Popup.qml
@@ -21,11 +21,11 @@ T.Popup {
     }
 
     T.Overlay.modal: Rectangle {
-        color: Color.transparent(control.palette.shadow, 0.5)
+        color: Qt.alpha(control.palette.shadow, 0.5)
     }
 
     T.Overlay.modeless: Rectangle {
-        color: Color.transparent(control.palette.shadow, 0.12)
+        color: Qt.alpha(control.palette.shadow, 0.12)
     }
 
     enter: Transition {

--- a/MMaterial/Components/Dialogs/Dialog.qml
+++ b/MMaterial/Components/Dialogs/Dialog.qml
@@ -156,10 +156,10 @@ T.Dialog {
     }
 
     T.Overlay.modal: Rectangle {
-        color: Color.transparent(MMaterial.Theme.background.paper, 0.5)
+        color: Qt.alpha(MMaterial.Theme.background.paper, 0.5)
     }
 
     T.Overlay.modeless: Rectangle {
-        color: Color.transparent(MMaterial.Theme.background.paper, 0.12)
+        color: Qt.alpha(MMaterial.Theme.background.paper, 0.12)
     }
 }

--- a/MMaterial/Components/Dialogs/InputDialog.qml
+++ b/MMaterial/Components/Dialogs/InputDialog.qml
@@ -144,10 +144,10 @@ T.Dialog {
     }
 
     T.Overlay.modal: Rectangle {
-        color: Color.transparent(MMaterial.Theme.background.paper, 0.5)
+        color: Qt.alpha(MMaterial.Theme.background.paper, 0.5)
     }
 
     T.Overlay.modeless: Rectangle {
-        color: Color.transparent(MMaterial.Theme.background.paper, 0.12)
+        color: Qt.alpha(MMaterial.Theme.background.paper, 0.12)
     }
 }

--- a/MMaterial/Components/Menu/Menu.qml
+++ b/MMaterial/Components/Menu/Menu.qml
@@ -60,10 +60,10 @@ T.Menu {
     }
 
     T.Overlay.modal: Rectangle {
-        color: Color.transparent(control.palette.shadow, 0.5)
+        color: Qt.alpha(control.palette.shadow, 0.5)
     }
 
     T.Overlay.modeless: Rectangle {
-        color: Color.transparent(control.palette.shadow, 0.12)
+        color: Qt.alpha(control.palette.shadow, 0.12)
     }
 }


### PR DESCRIPTION
This is a very simple pull request to solve a runtime error with the latest stable release of Qt (6.8), although this is a function that has existed since at least 6.2. Color.transparent doesn't seem to exist, and throws a runtime error when you attempt to create any of the elements that rely on it for transparency, instead defaulting to `#fff`, Thank you for all the work you do! I've been really enjoying using MMaterial :)

Before fix:
![Before fix](https://github.com/user-attachments/assets/be53a2f7-329f-41b9-9f57-bce47ba946e0)

After fix:
![After fix](https://github.com/user-attachments/assets/87edecc0-bcb5-4bdb-ad72-ccc9e8a579bc)

